### PR TITLE
Remove bash_it from homebrew recipe

### DIFF
--- a/sprout-osx-base/recipes/homebrew.rb
+++ b/sprout-osx-base/recipes/homebrew.rb
@@ -1,7 +1,6 @@
 return unless node["platform"] == "mac_os_x"
 
 include_recipe "sprout-osx-base::user_owns_usr_local"
-include_recipe "sprout-osx-base::bash_it"
 
 # Do not be tempted to use the git-resource to check out
 # homebrew directly into /usr/local; it will fail if


### PR DESCRIPTION
We don't want or need this dependency.
