### PR TITLE
Customize Mongo and RVM installations

### DIFF
--- a/pivotal_workstation/attributes/rvm.rb
+++ b/pivotal_workstation/attributes/rvm.rb
@@ -1,10 +1,2 @@
 node.default["rvm"] ||= {}
-node.default["rvm"]["rubies"] = {
-  # "ree-1.8.7-2012.02" => { :env => "CC=gcc-4.2" },
-  # "ruby-1.8.7-p358" => { :env => "CC=gcc-4.2" },
-  # "ruby-1.9.2-p290" => { :env => "CC=gcc-4.2" },
-  # "ruby-1.9.3-p194" => { :command_line_options => "--with-gcc=clang" }
-  "ruby-1.9.3-p392" => { :command_line_options => "--verify-downloads 1" }
-}
-
-node.default["rvm"]["default_ruby"] = "ruby-1.9.3-p392"
+node.default["rvm"]["rubies"] = {}

--- a/pivotal_workstation/recipes/mongodb.rb
+++ b/pivotal_workstation/recipes/mongodb.rb
@@ -1,9 +1,17 @@
 unless brew_installed? "mongodb"
-  brew "mongodb"
+  brew node['mongodb']['formula'] || "mongodb"
 
   directory "/Users/#{node['current_user']}/Library/LaunchAgents" do
     owner node['current_user']
     action :create
+  end
+
+  ruby_block "disable table scans" do
+    block do
+      conf_file = Chef::Util::FileEdit.new('/usr/local/etc/mongod.conf')
+      conf_file.insert_line_if_no_match(/^notablescan/, 'notablescan = true')
+      conf_file.write_file
+    end
   end
 
   execute "copy mongodb plist to ~/Library/LaunchAgents" do


### PR DESCRIPTION
Mongo:
- Allow custom formula to be installed (e.g. referencing a specific SHA)
- Update mongod.conf to disable table scans

RVM:
- Don't hardcode any default Rubies
- Remove unnecessary recipe and bash_it feature
- Simplify installation command to instructions from rvm.io
- Add node-customized gemsets for the default Ruby
