### PR TITLE
Add default empty gemsets and modify dot files

### DIFF
--- a/pivotal_workstation/attributes/rvm.rb
+++ b/pivotal_workstation/attributes/rvm.rb
@@ -1,2 +1,3 @@
 node.default["rvm"] ||= {}
 node.default["rvm"]["rubies"] = {}
+node.default["rvm"]["gemsets"] = []

--- a/pivotal_workstation/recipes/rvm.rb
+++ b/pivotal_workstation/recipes/rvm.rb
@@ -12,7 +12,7 @@ run_unless_marker_file_exists(marker_version_string_for("rvm")) do
   end
 
   execute 'download and install RVM' do
-    command 'curl -sSL https://get.rvm.io | bash'
+    command 'curl -sSL https://get.rvm.io | bash -s -- --auto-dotfiles'
     user node['current_user']
   end
 


### PR DESCRIPTION
This allows the recipe to be used without specifying any gemsets in the node
configuration.

Also, tell the RVM installer to modify the user's dot files to set up RVM.
