### PR TITLE
Update Qt and Heroku Toolbelt recipes

### DIFF
--- a/pivotal_workstation/attributes/heroku_toolbelt.rb
+++ b/pivotal_workstation/attributes/heroku_toolbelt.rb
@@ -1,0 +1,2 @@
+node.default['heroku_toolbelt'] = {}
+node.default['heroku_toolbelt']['plugins']= []

--- a/pivotal_workstation/recipes/qt.rb
+++ b/pivotal_workstation/recipes/qt.rb
@@ -1,3 +1,1 @@
-include_recipe "sprout-osx-apps::xquartz"
-
 brew "qt"

--- a/sprout-osx-apps/recipes/heroku_toolbelt.rb
+++ b/sprout-osx-apps/recipes/heroku_toolbelt.rb
@@ -1,1 +1,8 @@
 brew "heroku-toolbelt"
+
+node['heroku_toolbelt']['plugins'].each do |plugin|
+  execute "installing #{plugin} heroku toolbelt plugin" do
+    command "heroku plugins:install git://github.com/heroku/heroku-#{plugin}.git"
+    user node['current_user']
+  end
+end


### PR DESCRIPTION
- Remove unnecessary included recipe for Qt
- Allow Heroku Toolbelt plugins to be specified in the node configuration
