### PR TITLE
Update nginx recipe

### DIFF
--- a/pivotal_workstation/recipes/nginx.rb
+++ b/pivotal_workstation/recipes/nginx.rb
@@ -1,5 +1,4 @@
 include_recipe "sprout-osx-base::homebrew"
-include_recipe "pivotal_workstation::ssl_certificate"
 
 run_unless_marker_file_exists("nginx") do
 
@@ -40,5 +39,10 @@ end
 
 template "/usr/local/etc/nginx/nginx.conf" do
   source "nginx.conf.erb"
+  cookbook node['nginx_settings']['conf_template_cookbook'] || @cookbook_name.to_s
   owner node['current_user']
+end
+
+execute "reload the configuration" do
+  command "sudo nginx -s reload"
 end

--- a/pivotal_workstation/templates/default/org.nginx.nginx.plist.erb
+++ b/pivotal_workstation/templates/default/org.nginx.nginx.plist.erb
@@ -12,7 +12,7 @@
     <string>root</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/usr/local/sbin/nginx</string>
+        <string>/usr/local/bin/nginx</string>
         <string>-g</string>
         <string>daemon off;</string>
     </array>


### PR DESCRIPTION
- Remove include of SSL certificate recipe.  It isn't configurable, so we'll
  build a custom recipe instead.
- Allow the cookbook containing the nginx.conf template to be overridden, so it
  can be customized.
- Reload nginx after conf file changes.
- Correct path to nginx executable.  It's unclear why the orignal value was
  wrong - maybe something changed in homebrew since this repo was forked.
