### PR TITLE
Run nginx automatically on boot

### DIFF
--- a/pivotal_workstation/recipes/nginx.rb
+++ b/pivotal_workstation/recipes/nginx.rb
@@ -9,31 +9,38 @@ run_unless_marker_file_exists("nginx") do
 
   brew "nginx"
 
-  plist_path = File.expand_path('org.nginx.nginx.plist', File.join('~', 'Library', 'LaunchAgents'))
-  if File.exists?(plist_path)
-    log "nginx plist found at #{plist_path}"
-    execute "unload the plist (shuts down the daemon)" do
-      command %'launchctl unload -w #{plist_path}'
-      user "root"
+  plist_paths = [
+    File.join('', 'Library', 'LaunchDaemons'),
+    File.join('~', 'Library', 'LaunchAgents'),
+  ].map { |path| File.expand_path('org.nginx.nginx.plist', path) }
+
+  root_plist_path = plist_paths.first
+
+  plist_paths.each do |plist_path|
+    if File.exists?(plist_path)
+      log "nginx plist found at #{plist_path}"
+      execute "unload the plist (shuts down the daemon)" do
+        command %'launchctl unload -w #{plist_path}'
+        user "root"
+      end
+    else
+      log "Did not find plist at #{plist_path} don't try to unload it"
     end
-  else
-    log "Did not find plist at #{plist_path} don't try to unload it"
   end
 
-  launch_agents_path = File.expand_path('.', File.join('~', 'Library', 'LaunchAgents'))
-  directory launch_agents_path do
+  directory File.dirname(root_plist_path) do
     action :create
     recursive true
-    owner node['current_user']
+    owner 'root'
   end
 
-  template plist_path do
+  template root_plist_path do
     source "org.nginx.nginx.plist.erb"
     owner "root"
   end
 
   execute "start the daemon" do
-    command %'sudo launchctl load -w #{plist_path}'
+    command %'sudo launchctl load -w #{root_plist_path}'
   end
 end
 


### PR DESCRIPTION
This requires creating a system launch daemon instead of a user launch agent, so
the nginx process runs as root.  I also updated the old agent detection to look
for plist files in both locations.
